### PR TITLE
Fix memory leak

### DIFF
--- a/fiboheap.h
+++ b/fiboheap.h
@@ -67,11 +67,6 @@ class FibHeap
   {
     if (!x)
       return;
-    if (x->left == x->right && x->left == x)
-      {
-	delete x;
-	return;
-      }
     
     FibNode *cur = x;
     while(true)


### PR DESCRIPTION
It was sometimes failing to delete the children of a node.

I verified the memory leak exits using valgrind, and also that this fixes the leak.